### PR TITLE
Remove wasm_bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ futures = "0.1"
 rayon = "1.1.0"
 rayon-core = "1.5.0"
 log = '*'
+
+[features]
+std_atomics = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nobg-web_worker"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Dennis Kobert <dennis@kobert.dev>"]
 edition = "2018"
 repository = "https://github.com/squirrel-labs/web_worker"
@@ -16,7 +16,8 @@ license = "MPL-2.0"
 futures = "0.1"
 rayon = "1.1.0"
 rayon-core = "1.5.0"
-log = '*'
+log = "*"
+spin = "0.5"
 
 [features]
 std_atomics = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nobg-web_worker"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Dennis Kobert <dennis@kobert.dev>"]
 edition = "2018"
 repository = "https://github.com/squirrel-labs/web_worker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nobg-web_worker"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Dennis Kobert <dennis@kobert.dev>"]
 edition = "2018"
 repository = "https://github.com/squirrel-labs/web_worker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
-name = "web_worker"
+name = "nobg-web_worker"
 version = "0.3.0"
-authors = ["Joël Lupien (Jojolepro) <jojolepromain@gmail.com>"]
+authors = ["Dennis Kobert <dennis@kobert.dev>"]
 edition = "2018"
-documentation = "https://docs.rs/web_worker"
-repository = "https://github.com/jojolepro/web_worker"
+repository = "https://github.com/squirrel-labs/web_worker"
 categories = ["concurrency", "config", "wasm"]
 keywords = ["wasm", "web", "worker"]
 description = "A simple crate implementing web workers to run rayon-styled concurrent work on wasm."
@@ -14,25 +13,7 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-console_error_panic_hook = "0.1"
 futures = "0.1"
-js-sys = "0.3.33"
 rayon = "1.1.0"
 rayon-core = "1.5.0"
-wasm-bindgen = { version = "0.2.56", features = ['serde-serialize'] }
-wasm-bindgen-futures = "0.4.6"
-
-[dependencies.web-sys]
-version = "0.3.4"
-features = [
-  'CanvasRenderingContext2d',
-  'ErrorEvent',
-  'Event',
-  'ImageData',
-  'Navigator',
-  'Window',
-  'Worker',
-  'DedicatedWorkerGlobalScope',
-  'MessageEvent',
-]
-
+log = '*'

--- a/js/worker.js
+++ b/js/worker.js
@@ -2,18 +2,20 @@
 
 /* This section belongs in your existing source files
 let cached_wasm;
+let mem;
 
 function spawn_worker(id, stack_top) {
-    worker = new Webworker('js/worker.js');
+    worker = new Worker('js/worker.js');
 
-    worker.postMessage([cached_wasm, id, stack_top]);
+    worker.postMessage([cached_wasm, mem, id, stack_top]);
 
 }*/
 
 onmessage = async function({ data }) {
     data = data[0]
-    id = data[1]
-    stack_top = data[2]
+    mem = data[1]
+    id = data[2]
+    stack_top = data[3]
     wasm = await WebAssembly.instantiate(data.compiled, {env: {
         memory: mem
     }});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! Utilities to work with web workers and rayon.
 use rayon::ThreadPool;
 
+#[macro_use]
 extern crate log;
 
 mod pool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! Utilities to work with web workers and rayon.
 use rayon::ThreadPool;
 
-#[macro_use]
 extern crate log;
 
 mod pool;
@@ -35,7 +34,7 @@ pub fn set_global_thread_pool(
     let worker_pool = pool::WorkerPool::new(concurrency, stack_size, tls_size);
     match worker_pool {
         Ok(pool) => {
-            create_global_threadpool(concurrency, &pool).map_err(|e| format!("{}", e));
+            let _ = create_global_threadpool(concurrency, &pool).map_err(|e| log::error!("{}", e));
             Ok(pool)
         }
         Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,54 +1,18 @@
+#![feature(link_llvm_intrinsics)]
 //! Utilities to work with web workers and rayon.
-
 use rayon::ThreadPool;
-use wasm_bindgen::prelude::*;
-
-/// Macro allowing to write to the js/browser's console.
-/// You must import web_worker::log into scope to use this macro.
-#[macro_export]
-macro_rules! console_log {
-    ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
-}
 
 mod pool;
 
 pub use pool::*;
 
-#[wasm_bindgen]
-extern "C" {
-    /// External binding to the js console.log method. You probably want to use console_log!() instead
-    /// of this.
-    #[wasm_bindgen(js_namespace = console)]
-    pub fn log(s: &str);
-    #[wasm_bindgen(js_namespace = console, js_name = log)]
-    fn logv(x: &JsValue);
-}
-
-/// Initializes the logging of panics originating from the rust code.
-/// Must be called once at the start of the execution.
-pub fn init_panic_hook() {
-    console_error_panic_hook::set_once();
-}
-
 /// Creates a new `rayon::ThreadPool` with default concurrency value provided by the browser
-pub fn default_thread_pool(concurrency: Option<usize>) -> Option<ThreadPool> {
-    let concurrency = concurrency.unwrap_or_else(|| {
-        match web_sys::window() {
-            Some(window) => {
-                window.navigator().hardware_concurrency() as usize
-            },
-            None => {
-                console_log!("Failed to get hardware concurrency from window. This function is only available in the main browser thread.");
-                2
-            }
-        }
-    });
-
-    let worker_pool = pool::WorkerPool::new(concurrency);
+pub fn default_thread_pool(concurrency: usize) -> Option<ThreadPool> {
+    let worker_pool = pool::WorkerPool::new(concurrency, 1024 * 64);
     match worker_pool {
         Ok(pool) => Some(new_thread_pool(concurrency, &pool)),
         Err(e) => {
-            console_log!("Failed to create WorkerPool: {:?}", e);
+            log::error!("Failed to create WorkerPool: {:?}", e);
             None
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 #![feature(link_llvm_intrinsics)]
+#![feature(stdsimd)]
 //! Utilities to work with web workers and rayon.
 use rayon::ThreadPool;
+
+#[macro_use]
+extern crate log;
 
 mod pool;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,13 @@ mod pool;
 
 pub use pool::*;
 
-/// Creates a new `rayon::ThreadPool` with default concurrency value provided by the browser
-pub fn default_thread_pool(concurrency: usize) -> Option<ThreadPool> {
-    let worker_pool = pool::WorkerPool::new(concurrency, 1024 * 64);
+/// Creates a new `rayon::ThreadPool` with concurrency
+pub fn default_thread_pool(
+    concurrency: usize,
+    stack_size: u32,
+    tls_size: u32,
+) -> Option<ThreadPool> {
+    let worker_pool = pool::WorkerPool::new(concurrency, stack_size, tls_size);
     match worker_pool {
         Ok(pool) => Some(new_thread_pool(concurrency, &pool)),
         Err(e) => {
@@ -22,7 +26,23 @@ pub fn default_thread_pool(concurrency: usize) -> Option<ThreadPool> {
     }
 }
 
-/// Creates a new `rayon::ThreadPool` from the provided WorkerPool (created in the javascript code)
+/// Creates a new `rayon::ThreadPool` with concurrency
+pub fn set_global_thread_pool(
+    concurrency: usize,
+    stack_size: u32,
+    tls_size: u32,
+) -> Result<(), String> {
+    let worker_pool = pool::WorkerPool::new(concurrency, stack_size, tls_size);
+    match worker_pool {
+        Ok(pool) => create_global_threadpool(concurrency, &pool).map_err(|e| format!("{}", e)),
+        Err(e) => {
+            log::error!("Failed to create WorkerPool: {:?}", e);
+            Err(e)
+        }
+    }
+}
+
+/// Creates a new `rayon::ThreadPool` from the provided WorkerPool
 /// and the concurrency value, which indicates the number of threads to use.
 pub fn new_thread_pool(concurrency: usize, pool: &WorkerPool) -> ThreadPool {
     rayon::ThreadPoolBuilder::new()
@@ -30,4 +50,16 @@ pub fn new_thread_pool(concurrency: usize, pool: &WorkerPool) -> ThreadPool {
         .spawn_handler(|thread| Ok(pool.run(|| thread.run()).unwrap()))
         .build()
         .unwrap()
+}
+
+/// Creates a new `rayon::ThreadPool` from the provided WorkerPool (created in the javascript code)
+/// and the concurrency value, which indicates the number of threads to use.
+pub fn create_global_threadpool(
+    concurrency: usize,
+    pool: &WorkerPool,
+) -> Result<(), rayon::ThreadPoolBuildError> {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(concurrency)
+        .spawn_handler(|thread| Ok(pool.run(|| thread.run()).unwrap()))
+        .build_global()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@ pub fn default_thread_pool(
     concurrency: usize,
     stack_size: u32,
     tls_size: u32,
-) -> Option<ThreadPool> {
+) -> Option<(ThreadPool, pool::WorkerPool)> {
     let worker_pool = pool::WorkerPool::new(concurrency, stack_size, tls_size);
     match worker_pool {
-        Ok(pool) => Some(new_thread_pool(concurrency, &pool)),
+        Ok(pool) => Some((new_thread_pool(concurrency, &pool), pool)),
         Err(e) => {
             log::error!("Failed to create WorkerPool: {:?}", e);
             None
@@ -31,10 +31,13 @@ pub fn set_global_thread_pool(
     concurrency: usize,
     stack_size: u32,
     tls_size: u32,
-) -> Result<(), String> {
+) -> Result<pool::WorkerPool, String> {
     let worker_pool = pool::WorkerPool::new(concurrency, stack_size, tls_size);
     match worker_pool {
-        Ok(pool) => create_global_threadpool(concurrency, &pool).map_err(|e| format!("{}", e)),
+        Ok(pool) => {
+            create_global_threadpool(concurrency, &pool).map_err(|e| format!("{}", e));
+            Ok(pool)
+        }
         Err(e) => {
             log::error!("Failed to create WorkerPool: {:?}", e);
             Err(e)

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -177,7 +177,9 @@ mod atomics {
 
 /// Entry point invoked by `worker.js`
 /// The worker.available has to be set prior to its invokation
-pub extern fn child_entry_point(ptr: u32) {
+/// # Safety
+/// this function should be safe, as long as it is called with valid arguments
+pub unsafe extern "C" fn child_entry_point(ptr: u32) {
     let mut worker = ptr as *mut Worker;
 
     loop {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -170,13 +170,23 @@ impl WorkerPool {
 }
 
 mod atomics {
-    #[cfg(feature = "std_atomics")]
+    #[cfg(all(feature = "std_atomics", target_arch = "wasm32"))]
     pub use core::arch::wasm32::{memory_atomic_notify, memory_atomic_wait32};
 
-    #[cfg(not(feature = "std_atomics"))]
+    #[cfg(all(not(feature = "std_atomics"), target_arch = "wasm32"))]
     pub use llvm_intrinsic::*;
 
-    #[cfg(not(feature = "std_atomics"))]
+    #[cfg(not(target_arch = "wasm32"))]
+    pub unsafe fn memory_atomic_wait32(ptr: *mut i32, expression: i32, timeout_ns: i64) -> i32 {
+        0
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub unsafe fn memory_atomic_notify(ptr: *mut i32, waiters: u32) -> u32 {
+        0
+    }
+
+    #[cfg(all(not(feature = "std_atomics"), target_arch = "wasm32"))]
     mod llvm_intrinsic {
         extern "C" {
             #[link_name = "llvm.wasm.atomic.wait.i32"]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -177,7 +177,7 @@ mod atomics {
 
 /// Entry point invoked by `worker.js`
 /// The worker.available has to be set prior to its invokation
-pub unsafe fn child_entry_point(ptr: u32) {
+pub extern fn child_entry_point(ptr: u32) {
     let mut worker = ptr as *mut Worker;
 
     loop {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,37 +1,34 @@
 //! A small module that's intended to provide an example of creating a pool of
 //! web workers which can be used to execute `rayon`-style work.
-
-use futures::sync::oneshot;
-use futures::Future;
-use std::cell::{RefCell, UnsafeCell};
-use std::mem;
+use std::borrow::Borrow;
+#[cfg_attr(not(feature = "std_atomics"), feature(link_llvm_intrinsics))]
+use std::cell::RefCell;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
-use std::sync::Arc;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use web_sys::{DedicatedWorkerGlobalScope, MessageEvent};
-use web_sys::{ErrorEvent, Event, Worker};
-
-use crate::log;
 
 /// The `WorkerPool`. This is a special type of thread pool that works on wasm and provide a way to
 /// run work they way rayon does it.
-#[wasm_bindgen]
 pub struct WorkerPool {
     state: Rc<PoolState>,
+    stack_size: u32,
 }
 
 struct PoolState {
     workers: RefCell<Vec<Worker>>,
-    callback: Closure<dyn FnMut(Event)>,
+}
+
+struct Worker {
+    available: i32,
+    work_item: Option<Work>,
 }
 
 struct Work {
     func: Box<dyn FnOnce() + Send>,
 }
 
-#[wasm_bindgen]
+extern "C" {
+    fn spawn_worker(id: u32, stack_top: u32);
+}
+
 impl WorkerPool {
     /// Creates a new `WorkerPool` which immediately creates `initial` workers.
     ///
@@ -43,20 +40,16 @@ impl WorkerPool {
     ///
     /// Returns any error that may happen while a JS web worker is created and a
     /// message is sent to it.
-    #[wasm_bindgen(constructor)]
-    pub fn new(initial: usize) -> Result<WorkerPool, JsValue> {
+    pub fn new(initial: usize, stack_size: u32) -> Result<WorkerPool, String> {
         let pool = WorkerPool {
             state: Rc::new(PoolState {
                 workers: RefCell::new(Vec::with_capacity(initial)),
-                callback: Closure::wrap(Box::new(|event: Event| {
-                    console_log!("unhandled event: {}", event.type_());
-                    crate::logv(&event);
-                }) as Box<dyn FnMut(Event)>),
             }),
+            stack_size,
         };
         for _ in 0..initial {
             let worker = pool.spawn()?;
-            pool.state.push(worker);
+            pool.state.workers.borrow_mut().push(worker);
         }
 
         Ok(pool)
@@ -71,25 +64,22 @@ impl WorkerPool {
     ///
     /// Returns any error that may happen while a JS web worker is created and a
     /// message is sent to it.
-    fn spawn(&self) -> Result<Worker, JsValue> {
-        console_log!("spawning new worker");
-        // TODO: what do do about `./worker.js`:
-        //
-        // * the path is only known by the bundler. How can we, as a
-        //   library, know what's going on?
-        // * How do we not fetch a script N times? It internally then
-        //   causes another script to get fetched N times...
-        let worker = Worker::new("./worker.js")?;
+    fn spawn(&self) -> Result<Worker, String> {
+        log::debug!("spawning new worker");
 
+        unsafe {
+            let layout =
+                core::alloc::Layout::from_size_align_unchecked(self.stack_size as usize, 16);
+            let stack_top = std::alloc::alloc(layout);
+            spawn_worker(self.state.workers.borrow().len() as u32, stack_top as u32);
+        }
         // With a worker spun up send it the module/memory so it can start
         // instantiating the wasm module. Later it might receive further
         // messages about code to run on the wasm module.
-        let array = js_sys::Array::new();
-        array.push(&wasm_bindgen::module());
-        array.push(&wasm_bindgen::memory());
-        worker.post_message(&array)?;
-
-        Ok(worker)
+        Ok(Worker {
+            available: 1,
+            work_item: None,
+        })
     }
 
     /// Fetches a worker from this pool, spawning one if necessary.
@@ -98,15 +88,21 @@ impl WorkerPool {
     /// if one is available, otherwise it will spawn a new worker and return the
     /// newly spawned worker.
     ///
-    /// # Errors
+    /// # Safety
+    /// This function is not thread safe!
+    /// Never attempt to spawn more than one thread at a time!
     ///
-    /// Returns any error that may happen while a JS web worker is created and a
-    /// message is sent to it.
-    fn worker(&self) -> Result<Worker, JsValue> {
-        match self.state.workers.borrow_mut().pop() {
-            Some(worker) => Ok(worker),
-            None => self.spawn(),
+    fn worker(&self) -> Result<usize, String> {
+        let state: PoolState = *self.state.borrow();
+        let workers: &Vec<Worker> = (state.workers.borrow()).as_ref();
+        for (id, worker) in workers.iter().enumerate() {
+            if worker.available == 1 {
+                return Ok(id);
+            }
         }
+
+        self.state.workers.borrow_mut().push(self.spawn()?);
+        Ok(self.state.workers.borrow().len() - 1)
     }
 
     /// Executes the work `f` in a web worker, spawning a web worker if
@@ -121,62 +117,12 @@ impl WorkerPool {
     ///
     /// Returns any error that may happen while a JS web worker is created and a
     /// message is sent to it.
-    fn execute(&self, f: impl FnOnce() + Send + 'static) -> Result<Worker, JsValue> {
-        let worker = self.worker()?;
-        let work = Box::new(Work { func: Box::new(f) });
-        let ptr = Box::into_raw(work);
-        match worker.post_message(&JsValue::from(ptr as u32)) {
-            Ok(()) => Ok(worker),
-            Err(e) => {
-                unsafe {
-                    drop(Box::from_raw(ptr));
-                }
-                Err(e)
-            }
-        }
-    }
-
-    /// Configures an `onmessage` callback for the `worker` specified for the
-    /// web worker to be reclaimed and re-inserted into this pool when a message
-    /// is received.
-    ///
-    /// Currently this `WorkerPool` abstraction is intended to execute one-off
-    /// style work where the work itself doesn't send any notifications and
-    /// whatn it's done the worker is ready to execute more work. This method is
-    /// used for all spawned workers to ensure that when the work is finished
-    /// the worker is reclaimed back into this pool.
-    fn reclaim_on_message(&self, worker: Worker, on_finish: impl FnOnce() + 'static) {
-        let state = Rc::downgrade(&self.state);
-        let worker2 = worker.clone();
-        let reclaim_slot = Rc::new(RefCell::new(None));
-        let slot2 = reclaim_slot.clone();
-        let mut on_finish = Some(on_finish);
-        let reclaim = Closure::wrap(Box::new(move |event: Event| {
-            if let Some(error) = event.dyn_ref::<ErrorEvent>() {
-                console_log!("error in worker: {}", error.message());
-                // TODO: this probably leaks memory somehow? It's sort of
-                // unclear what to do about errors in workers right now.
-                return;
-            }
-
-            // If this is a completion event then we can execute our `on_finish`
-            // callback and we can also deallocate our own callback by clearing
-            // out `slot2` which contains our own closure.
-            if let Some(_msg) = event.dyn_ref::<MessageEvent>() {
-                on_finish.take().unwrap()();
-                if let Some(state) = state.upgrade() {
-                    state.push(worker2.clone());
-                }
-                *slot2.borrow_mut() = None;
-                return;
-            }
-
-            console_log!("unhandled event: {}", event.type_());
-            crate::logv(&event);
-            // TODO: like above, maybe a memory leak here?
-        }) as Box<dyn FnMut(Event)>);
-        worker.set_onmessage(Some(reclaim.as_ref().unchecked_ref()));
-        *reclaim_slot.borrow_mut() = Some(reclaim);
+    fn execute(&self, f: impl FnOnce() + Send + 'static) -> Result<(), String> {
+        let worker = self.state.workers.borrow_mut()[self.worker()?];
+        assert_eq!(worker.available, 1);
+        let work = Work { func: Box::new(f) };
+        worker.work_item = Some(work);
+        Ok(())
     }
 }
 
@@ -195,105 +141,48 @@ impl WorkerPool {
     ///
     /// If an error happens while spawning a web worker or sending a message to
     /// a web worker, that error is returned.
-    pub fn run(&self, f: impl FnOnce() + Send + 'static) -> Result<(), JsValue> {
-        let worker = self.execute(f)?;
-        self.reclaim_on_message(worker, || {});
-        Ok(())
-    }
-
-    /// Executes the closure `f` in a web worker, returning a future of the
-    /// value that `f` produces.
-    ///
-    /// This method is the same as `run` execept that it allows recovering the
-    /// return value of the closure `f` in a nonblocking fashion with the future
-    /// returned.
-    ///
-    /// # Errors
-    ///
-    /// If an error happens while spawning a web worker or sending a message to
-    /// a web worker, that error is returned.
-    pub fn run_notify<T>(
-        &self,
-        f: impl FnOnce() -> T + Send + 'static,
-    ) -> Result<impl Future<Item = T, Error = JsValue> + 'static, JsValue>
-    where
-        T: Send + 'static,
-    {
-        // FIXME(#1379) we should just use the `oneshot` directly as the future,
-        // but we have to use JS callbacks to ensure we don't have futures cross
-        // threads as that's currently not safe to do so.
-        let (tx, rx) = oneshot::channel();
-        let storage = Arc::new(AtomicValue::new(None));
-        let storage2 = storage.clone();
-        let worker = self.execute(move || {
-            assert!(storage2.replace(Some(f())).is_ok());
-        })?;
-        self.reclaim_on_message(worker, move || match storage.replace(None) {
-            Ok(Some(val)) => drop(tx.send(val)),
-            _ => unreachable!(),
-        });
-
-        Ok(rx.map_err(|_| JsValue::undefined()))
+    pub fn run(&self, f: impl FnOnce() + Send + 'static) -> Result<(), String> {
+        self.execute(f)
     }
 }
 
-/// A small helper struct representing atomic access to an internal value `T`
-///
-/// This struct only supports one API, `replace`, which will either succeed and
-/// replace the internal value with another (returning the previous one), or it
-/// will fail returning the value passed in. Failure happens when two threads
-/// try to `replace` at the same time.
-///
-/// This is only really intended to help safely transfer information between
-/// threads, it doesn't provide any synchronization capabilities itself other
-/// than a guaranteed safe API.
-struct AtomicValue<T> {
-    modifying: AtomicBool,
-    slot: UnsafeCell<T>,
-}
+mod atomics {
+    #[cfg(feature = "std_atomics")]
+    pub use core::arch::wasm32::{atomic_notify, i32_atomic_wait};
 
-unsafe impl<T: Send> Send for AtomicValue<T> {}
-unsafe impl<T: Send> Sync for AtomicValue<T> {}
+    #[cfg(not(feature = "std_atomics"))]
+    pub use llvm_intrinsic::*;
 
-impl<T> AtomicValue<T> {
-    fn new(val: T) -> AtomicValue<T> {
-        AtomicValue {
-            modifying: AtomicBool::new(false),
-            slot: UnsafeCell::new(val),
+    #[cfg(not(feature = "std_atomics"))]
+    mod llvm_intrinsic {
+        extern "C" {
+            #[link_name = "llvm.wasm.atomic.wait.i32"]
+            fn llvm_atomic_wait_i32(ptr: *mut i32, exp: i32, timeout: i64) -> i32;
+            #[link_name = "llvm.wasm.atomic.notify"]
+            fn llvm_atomic_notify(ptr: *mut i32, cnt: i32) -> i32;
+        }
+
+        #[inline]
+        pub unsafe fn i32_atomic_wait(ptr: *mut i32, expression: i32, timeout_ns: i64) -> i32 {
+            llvm_atomic_wait_i32(ptr, expression, timeout_ns)
+        }
+        #[inline]
+        pub unsafe fn atomic_notify(ptr: *mut i32, waiters: u32) -> u32 {
+            llvm_atomic_notify(ptr, waiters as i32) as u32
         }
     }
-
-    fn replace(&self, val: T) -> Result<T, T> {
-        if self.modifying.swap(true, SeqCst) {
-            return Err(val);
-        }
-        let ret = unsafe { mem::replace(&mut *self.slot.get(), val) };
-        self.modifying.store(false, SeqCst);
-        Ok(ret)
-    }
 }
 
-impl PoolState {
-    fn push(&self, worker: Worker) {
-        worker.set_onmessage(Some(self.callback.as_ref().unchecked_ref()));
-        worker.set_onerror(Some(self.callback.as_ref().unchecked_ref()));
-        let mut workers = self.workers.borrow_mut();
-        for prev in workers.iter() {
-            let prev: &JsValue = prev;
-            let worker: &JsValue = &worker;
-            assert!(prev != worker);
-        }
-        workers.push(worker);
-    }
-}
+/// Entry point invoked by `worker.js`
+/// The worker.available has to be set prior to its invokation
+pub unsafe fn child_entry_point(ptr: u32) {
+    let mut worker = ptr as *mut Worker;
 
-/// Entry point invoked by `worker.js`, a bit of a hack but see the "TODO" above
-/// about `worker.js` in general.
-#[wasm_bindgen]
-pub fn child_entry_point(ptr: u32) -> Result<(), JsValue> {
-    let ptr = unsafe { Box::from_raw(ptr as *mut Work) };
-    let global = js_sys::global().unchecked_into::<DedicatedWorkerGlobalScope>();
-    (ptr.func)();
-    global.post_message(&JsValue::undefined())?;
-    Ok(())
+    loop {
+        if let Some(work) = (*worker).work_item {
+            (work.func)();
+        }
+        (*worker).available = 1;
+        atomics::i32_atomic_wait(&mut (*worker).available as *mut i32, 1, -1);
+    }
 }


### PR DESCRIPTION
Remove the depenency on wasm-bindgen and improve efficiency by utilizing atomic waits.

- [ ] implement rust code

- [ ] implement javascript glue

- [ ] do some testing + performance checking